### PR TITLE
feat: adding Neuralyzer.get_model method

### DIFF
--- a/django_neuralyzer/management/commands/ensure_fields_are_handled.py
+++ b/django_neuralyzer/management/commands/ensure_fields_are_handled.py
@@ -29,7 +29,7 @@ class Command(BaseCommand):
 
         for klass in anon_classes:
             print(f"Neuralyzer: {klass}")
-            model = klass.Meta.model
+            model = klass.get_model()
             neuralyzer = klass()
             anon_fields = neuralyzer._get_class_attributes()
             noop_fields = neuralyzer._excluded_attributes


### PR DESCRIPTION
PR for #2 

With this PR, `Meta.model` can be string like `"app.model"`.
```py
class PersonNeuralyzer(BaseNeuralyzer)
    class Meta:
        model = "app.Person"
```